### PR TITLE
chore: HTML entity in backticks in FAQS

### DIFF
--- a/content/faq/how-do-i-resolve-multipart-error.md
+++ b/content/faq/how-do-i-resolve-multipart-error.md
@@ -1,5 +1,5 @@
 ---
-title: "How do I resolve error `Unknown variable: &amp;MULTIPART\_PART\_HEADERS`?"
+title: "How do I resolve error `Unknown variable: &MULTIPART\_PART\_HEADERS`?"
 weight: 11
 noindex: true
 ---


### PR DESCRIPTION


Seems like the HTML entity `&amp;` is not properly rendered inside backticks. 

Old Website:
![image](https://github.com/coreruleset/website/assets/26764726/2c718745-9512-49a6-8421-1e9ad7920b9d)


New:
![image](https://github.com/coreruleset/website/assets/26764726/242ff784-841f-46ae-a226-14ffb2db7435)