### PR TITLE
chore: remove url in post to use permalinks

### DIFF
--- a/config/_default/hugo.yaml
+++ b/config/_default/hugo.yaml
@@ -26,3 +26,7 @@ privacy:
   vimeo:
     enableDNT: true
 
+# Links
+permalinks:
+  page:
+    blog: /:year:month:day/:slug/

--- a/content/blog/2017-07-27-crs3-presentation-owasp-london.md
+++ b/content/blog/2017-07-27-crs3-presentation-owasp-london.md
@@ -4,7 +4,6 @@ categories:
   - Blog
 date: '2017-07-27T17:44:30+02:00'
 title: CRS3 presentation at OWASP London
-url: /2017/07/27/crs3-presentation-owasp-london/
 ---
 
 

--- a/content/blog/2017-08-10-modsecurity-version-2-9-2-released.md
+++ b/content/blog/2017-08-10-modsecurity-version-2-9-2-released.md
@@ -4,7 +4,6 @@ categories:
   - Blog
 date: '2017-08-10T12:48:47+02:00'
 title: ModSecurity version 2.9.2 released
-url: /2017/08/10/modsecurity-version-2-9-2-released/
 ---
 
 Trustwave has released [ModSecurity version 2.9.2](https://www.trustwave.com/Resources/SpiderLabs-Blog/Announcing-ModSecurity-version-2-9-2/).

--- a/content/blog/2017-08-10-testing-wafs-ftw-version-1-0-released.md
+++ b/content/blog/2017-08-10-testing-wafs-ftw-version-1-0-released.md
@@ -4,7 +4,6 @@ categories:
   - Blog
 date: '2017-08-10T21:28:14+02:00'
 title: Testing WAFs, FTW Version 1.0 released
-url: /2017/08/10/testing-wafs-ftw-version-1-0-released/
 ---
 
 

--- a/content/blog/2017-08-15-crs-project-news-august-2017.md
+++ b/content/blog/2017-08-15-crs-project-news-august-2017.md
@@ -4,7 +4,6 @@ categories:
   - Blog
 date: '2017-08-15T13:48:36+02:00'
 title: CRS Project News August 2017
-url: /2017/08/15/crs-project-news-august-2017/
 ---
 
 

--- a/content/blog/2017-08-21-running-crs-rules-only-on-certain-parameters.md
+++ b/content/blog/2017-08-21-running-crs-rules-only-on-certain-parameters.md
@@ -4,7 +4,6 @@ categories:
   - Blog
 date: '2017-08-21T22:48:36+02:00'
 title: Running CRS rules only on certain parameters
-url: /2017/08/21/running-crs-rules-only-on-certain-parameters/
 ---
 
 

--- a/content/blog/2017-09-07-crs-project-news-september-2017.md
+++ b/content/blog/2017-09-07-crs-project-news-september-2017.md
@@ -6,7 +6,6 @@ date: '2017-09-07T16:18:20+02:00'
 tags:
   - CRS-News
 title: CRS Project News September 2017
-url: /2017/09/07/crs-project-news-september-2017/
 ---
 
 

--- a/content/blog/2017-09-13-how-you-can-help-the-crs-project.md
+++ b/content/blog/2017-09-13-how-you-can-help-the-crs-project.md
@@ -6,7 +6,6 @@ date: '2017-09-13T20:35:50+02:00'
 tags:
   - ProjectSupport
 title: How You Can Help the CRS Project
-url: /2017/09/13/how-you-can-help-the-crs-project/
 ---
 
 

--- a/content/blog/2017-09-15-writing-ftw-test-cases-for-owasp-crs.md
+++ b/content/blog/2017-09-15-writing-ftw-test-cases-for-owasp-crs.md
@@ -4,7 +4,6 @@ categories:
   - Blog
 date: '2017-09-15T03:10:31+02:00'
 title: Writing FTW test cases for OWASP CRS
-url: /2017/09/15/writing-ftw-test-cases-for-owasp-crs/
 ---
 
 

--- a/content/blog/2017-09-20-optionsbleed.md
+++ b/content/blog/2017-09-20-optionsbleed.md
@@ -4,7 +4,6 @@ categories:
   - Blog
 date: '2017-09-20T03:15:37+02:00'
 title: OptionsBleed Defenses
-url: /2017/09/20/optionsbleed/
 ---
 
 

--- a/content/blog/2017-10-03-crs-project-news-october-2017.md
+++ b/content/blog/2017-10-03-crs-project-news-october-2017.md
@@ -4,7 +4,6 @@ categories:
   - Blog
 date: '2017-10-03T15:11:36+02:00'
 title: CRS Project News October 2017
-url: /2017/10/03/crs-project-news-october-2017/
 ---
 
 

--- a/content/blog/2017-10-03-crs-project-nominated-for-swiss-dinacon-award.md
+++ b/content/blog/2017-10-03-crs-project-nominated-for-swiss-dinacon-award.md
@@ -6,7 +6,6 @@ date: '2017-10-03T07:25:59+02:00'
 tags:
   - DINACon
 title: CRS Project Nominated for Swiss DINACon Award
-url: /2017/10/03/crs-project-nominated-for-swiss-dinacon-award/
 ---
 
 The Core Rule Set project (CRS for short) has been nominated for the Swiss [DINAcon Awards](https://dinacon.ch/en/dinacon-awards/). I do not think any of you understand what awards I am talking about, so let me explain.

--- a/content/blog/2017-11-07-crs-project-news-november.md
+++ b/content/blog/2017-11-07-crs-project-news-november.md
@@ -4,7 +4,6 @@ categories:
   - Blog
 date: '2017-11-07T01:46:59+01:00'
 title: CRS Project News November
-url: /2017/11/07/crs-project-news-november/
 ---
 
 This is the CRS newsletter covering the period from Early October until today.

--- a/content/blog/2017-11-09-disassembling-sqli-rules.md
+++ b/content/blog/2017-11-09-disassembling-sqli-rules.md
@@ -4,7 +4,6 @@ categories:
   - Blog
 date: '2017-11-09T14:30:37+01:00'
 title: Disassembling SQLi Rules
-url: /2017/11/09/disassembling-sqli-rules/
 ---
 
 ## Introduction

--- a/content/blog/2017-11-21-top-5-ways-crs-can-help-you-fight-owasp-top-10.md
+++ b/content/blog/2017-11-21-top-5-ways-crs-can-help-you-fight-owasp-top-10.md
@@ -9,7 +9,6 @@ tags:
   - OWASPTop10
   - SQLInjection
 title: The Top 5 Ways CRS Can Help You Fight the OWASP Top 10
-url: /2017/11/21/top-5-ways-crs-can-help-you-fight-owasp-top-10/
 ---
 
 

--- a/content/blog/2017-12-07-core-rule-set-project-winning-osbar-award.md
+++ b/content/blog/2017-12-07-core-rule-set-project-winning-osbar-award.md
@@ -7,7 +7,6 @@ tags:
   - ModSecurity
   - OSBAR
 title: Core Rule Set Project Won a German OSBAR Award!
-url: /2017/12/07/core-rule-set-project-winning-osbar-award/
 ---
 
 

--- a/content/blog/2017-12-07-new-modsecurity-crs-courses-announced.md
+++ b/content/blog/2017-12-07-new-modsecurity-crs-courses-announced.md
@@ -4,7 +4,6 @@ categories:
   - Blog
 date: '2017-12-07T12:13:05+01:00'
 title: New ModSecurity / CRS Courses Announced
-url: /2017/12/07/new-modsecurity-crs-courses-announced/
 ---
 
 

--- a/content/blog/2017-12-12-crs-project-news-december-2017.md
+++ b/content/blog/2017-12-12-crs-project-news-december-2017.md
@@ -4,7 +4,6 @@ categories:
   - Blog
 date: '2017-12-12T16:20:35+01:00'
 title: CRS Project News December 2017
-url: /2017/12/12/crs-project-news-december-2017/
 ---
 
 

--- a/content/blog/2017-12-14-practical-ftw-testing-the-core-rule-set-or-any-other-waf.md
+++ b/content/blog/2017-12-14-practical-ftw-testing-the-core-rule-set-or-any-other-waf.md
@@ -7,7 +7,6 @@ tags:
   - ftw
   - testing
 title: 'Practical FTW: Testing the Core Rule Set or Any Other WAF'
-url: /2017/12/14/practical-ftw-testing-the-core-rule-set-or-any-other-waf/
 ---
 
 

--- a/content/blog/2018-01-12-core-rule-set-the-evolution-of-an-owasp-project.md
+++ b/content/blog/2018-01-12-core-rule-set-the-evolution-of-an-owasp-project.md
@@ -4,7 +4,6 @@ categories:
   - Blog
 date: '2018-01-12T06:42:29+01:00'
 title: 'Core Rule Set: The evolution of an OWASP Project [x-post]'
-url: /2018/01/12/core-rule-set-the-evolution-of-an-owasp-project/
 ---
 
 

--- a/content/blog/2018-01-12-crs-project-new-january-2018.md
+++ b/content/blog/2018-01-12-crs-project-new-january-2018.md
@@ -4,7 +4,6 @@ categories:
   - Blog
 date: '2018-01-12T07:14:45+01:00'
 title: CRS Project News January 2018
-url: /2018/01/12/crs-project-new-january-2018/
 ---
 
 

--- a/content/blog/2018-02-11-crs-project-news-february-208.md
+++ b/content/blog/2018-02-11-crs-project-news-february-208.md
@@ -4,7 +4,6 @@ categories:
   - Blog
 date: '2018-02-11T05:10:03+01:00'
 title: CRS Project News February 2018
-url: /2018/02/11/crs-project-news-february-208/
 ---
 
 

--- a/content/blog/2018-02-21-how-to-tune-your-waf-installation-to-reduce-false-positives.md
+++ b/content/blog/2018-02-21-how-to-tune-your-waf-installation-to-reduce-false-positives.md
@@ -4,7 +4,6 @@ categories:
   - Blog
 date: '2018-02-21T06:00:52+01:00'
 title: How to tune your WAF installation to reduce false positives [x-post]
-url: /2018/02/21/how-to-tune-your-waf-installation-to-reduce-false-positives/
 draft: true
 ---
 

--- a/content/blog/2018-03-08-building-the-waf-test-harness-x-post.md
+++ b/content/blog/2018-03-08-building-the-waf-test-harness-x-post.md
@@ -4,7 +4,6 @@ categories:
   - Blog
 date: '2018-03-08T18:21:30+01:00'
 title: Building the WAF test harness [x-post]
-url: /2018/03/08/building-the-waf-test-harness-x-post/
 ---
 
 

--- a/content/blog/2018-03-10-creating-an-openwaf-solution-with-nginx-elasticsearch-and-modsecurity-x-post.md
+++ b/content/blog/2018-03-10-creating-an-openwaf-solution-with-nginx-elasticsearch-and-modsecurity-x-post.md
@@ -4,7 +4,6 @@ categories:
   - Blog
 date: '2018-03-10T20:39:10+01:00'
 title: Creating an OpenWAF solution with Nginx, ElasticSearch and ModSecurity [x-post]
-url: /2018/03/10/creating-an-openwaf-solution-with-nginx-elasticsearch-and-modsecurity-x-post/
 ---
 
 So many technologies in one title!

--- a/content/blog/2018-03-14-crs-project-news-march-2018.md
+++ b/content/blog/2018-03-14-crs-project-news-march-2018.md
@@ -4,7 +4,6 @@ categories:
   - Blog
 date: '2018-03-14T06:37:37+01:00'
 title: CRS Project News March 2018
-url: /2018/03/14/crs-project-news-march-2018/
 ---
 
 

--- a/content/blog/2018-03-20-save-the-date-crs-community-summit-on-july-4-2018.md
+++ b/content/blog/2018-03-20-save-the-date-crs-community-summit-on-july-4-2018.md
@@ -6,7 +6,6 @@ date: '2018-03-20T07:48:37+01:00'
 tags:
   - CommunitySummit
 title: 'Save the Date: CRS Community Summit on July 4, 2018'
-url: /2018/03/20/save-the-date-crs-community-summit-on-july-4-2018/
 ---
 
 

--- a/content/blog/2018-06-07-registration-open-for-the-crs-community-summit-on-july-4.md
+++ b/content/blog/2018-06-07-registration-open-for-the-crs-community-summit-on-july-4.md
@@ -6,7 +6,6 @@ date: '2018-06-07T08:41:04+02:00'
 tags:
   - CommunitySummit
 title: Registration Open for the CRS Community Summit on July 4
-url: /2018/06/07/registration-open-for-the-crs-community-summit-on-july-4/
 ---
 
 

--- a/content/blog/2018-06-19-the-core-rule-set-as-part-of-devops-ci-pipeline.md
+++ b/content/blog/2018-06-19-the-core-rule-set-as-part-of-devops-ci-pipeline.md
@@ -4,7 +4,6 @@ categories:
   - Blog
 date: '2018-06-19T09:13:14+02:00'
 title: The Core Rule Set as Part of DevOps (CI pipeline)
-url: /2018/06/19/the-core-rule-set-as-part-of-devops-ci-pipeline/
 ---
 
 

--- a/content/blog/2018-06-26-crs-community-summit-next-week-call-for-posters-and-the-program-is-ready.md
+++ b/content/blog/2018-06-26-crs-community-summit-next-week-call-for-posters-and-the-program-is-ready.md
@@ -6,7 +6,6 @@ date: '2018-06-26T10:27:14+02:00'
 tags:
   - CommunitySummit
 title: 'CRS Community Summit next week: Call for Posters and the Program is Ready'
-url: /2018/06/26/crs-community-summit-next-week-call-for-posters-and-the-program-is-ready/
 ---
 
 

--- a/content/blog/2018-07-12-reporting-from-the-first-crs-community-summit-in-london.md
+++ b/content/blog/2018-07-12-reporting-from-the-first-crs-community-summit-in-london.md
@@ -4,7 +4,6 @@ categories:
   - Blog
 date: '2018-07-12T14:10:35+02:00'
 title: Reporting from the First CRS Community Summit in London
-url: /2018/07/12/reporting-from-the-first-crs-community-summit-in-london/
 ---
 
 

--- a/content/blog/2018-07-26-crs-project-news-july-2018.md
+++ b/content/blog/2018-07-26-crs-project-news-july-2018.md
@@ -7,7 +7,6 @@ tags:
   - CommunitySummit
   - CRS-News
 title: CRS Project News July 2018
-url: /2018/07/26/crs-project-news-july-2018/
 ---
 
 

--- a/content/blog/2018-08-09-appsec-podcast-interviewing-crs-project-co-lead-christian-folini.md
+++ b/content/blog/2018-08-09-appsec-podcast-interviewing-crs-project-co-lead-christian-folini.md
@@ -4,7 +4,6 @@ categories:
   - Blog
 date: '2018-08-09T22:23:26+02:00'
 title: AppSec Podcast Interviewing CRS Project Co-Lead Christian Folini
-url: /2018/08/09/appsec-podcast-interviewing-crs-project-co-lead-christian-folini/
 ---
 
 

--- a/content/blog/2018-09-02-web-application-firewall-waf-evasion-techniques-3-x-post.md
+++ b/content/blog/2018-09-02-web-application-firewall-waf-evasion-techniques-3-x-post.md
@@ -4,7 +4,6 @@ categories:
   - Blog
 date: '2018-09-02T19:02:42+02:00'
 title: 'Web Application Firewall (WAF) Evasion Techniques #3 [x-post]'
-url: /2018/09/02/web-application-firewall-waf-evasion-techniques-3-x-post/
 ---
 
 

--- a/content/blog/2018-09-13-some-thoughts-on-why-web-application-firewalls-really-make-a-difference.md
+++ b/content/blog/2018-09-13-some-thoughts-on-why-web-application-firewalls-really-make-a-difference.md
@@ -4,7 +4,6 @@ categories:
   - Blog
 date: '2018-09-13T06:41:21+02:00'
 title: Some Thoughts on why Web Application Firewalls Really Make a Difference
-url: /2018/09/13/some-thoughts-on-why-web-application-firewalls-really-make-a-difference/
 ---
 
 

--- a/content/blog/2018-09-27-crs-project-news-september-2018.md
+++ b/content/blog/2018-09-27-crs-project-news-september-2018.md
@@ -6,7 +6,6 @@ date: '2018-09-27T07:01:35+02:00'
 tags:
   - CRS-News
 title: CRS Project News September 2018
-url: /2018/09/27/crs-project-news-september-2018/
 ---
 
 

--- a/content/blog/2018-10-03-owasp-crs-slack.md
+++ b/content/blog/2018-10-03-owasp-crs-slack.md
@@ -4,7 +4,6 @@ categories:
   - Blog
 date: '2018-10-03T14:16:02+02:00'
 title: Join us on the OWASP Slack!
-url: /2018/10/03/owasp-crs-slack/
 ---
 
 

--- a/content/blog/2018-11-14-crs-project-news-november-2018.md
+++ b/content/blog/2018-11-14-crs-project-news-november-2018.md
@@ -6,7 +6,6 @@ date: '2018-11-14T22:04:29+01:00'
 tags:
   - CRS-News
 title: CRS Project News November 2018
-url: /2018/11/14/crs-project-news-november-2018/
 ---
 
 

--- a/content/blog/2018-11-28-announcement-owasp-modsecurity-core-rule-set-version-3-1-0.md
+++ b/content/blog/2018-11-28-announcement-owasp-modsecurity-core-rule-set-version-3-1-0.md
@@ -4,7 +4,6 @@ categories:
   - Blog
 date: '2018-11-28T23:08:03+01:00'
 title: 'Announcement: OWASP ModSecurity Core Rule Set Version 3.1.0'
-url: /2018/11/28/announcement-owasp-modsecurity-core-rule-set-version-3-1-0/
 ---
 
 

--- a/content/blog/2018-12-12-core-rule-set-docker-image.md
+++ b/content/blog/2018-12-12-core-rule-set-docker-image.md
@@ -4,7 +4,6 @@ categories:
   - Blog
 date: '2018-12-12T10:27:37+01:00'
 title: Core Rule Set Docker Image
-url: /2018/12/12/core-rule-set-docker-image/
 ---
 
 

--- a/content/blog/2018-12-26-crs-project-news-december-2018.md
+++ b/content/blog/2018-12-26-crs-project-news-december-2018.md
@@ -6,7 +6,6 @@ date: '2018-12-26T13:13:28+01:00'
 tags:
   - CRS-News
 title: CRS Project News December 2018
-url: /2018/12/26/crs-project-news-december-2018/
 ---
 
 

--- a/content/blog/2019-01-24-crs-project-news-january-2019.md
+++ b/content/blog/2019-01-24-crs-project-news-january-2019.md
@@ -6,7 +6,6 @@ date: '2019-01-24T16:37:11+01:00'
 tags:
   - CRS-News
 title: CRS Project News January 2019
-url: /2019/01/24/crs-project-news-january-2019/
 ---
 
 We are back with the CRS project news. We're attending the Cloudfest Hackathon in March in Germany and we have plans for another CRS Community Summit at the new OWASP AppSec Global conference in Tel Aviv at the end of May (formerly OWASP AppSecEU).

--- a/content/blog/2019-02-28-crs-project-news-february-2019.md
+++ b/content/blog/2019-02-28-crs-project-news-february-2019.md
@@ -4,7 +4,6 @@ categories:
   - Blog
 date: '2019-02-28T09:57:50+01:00'
 title: CRS Project News February 2019
-url: /2019/02/28/crs-project-news-february-2019/
 ---
 
 We are back with the CRS project news. The news are running very, very late in the month as I've been held up with other projects.

--- a/content/blog/2019-04-25-regular-expression-dos-weaknesses-in-crs.md
+++ b/content/blog/2019-04-25-regular-expression-dos-weaknesses-in-crs.md
@@ -12,7 +12,6 @@ tags:
 theme-transparent-header-meta:
   - default
 title: Regular Expression DoS weaknesses in CRS
-url: /2019/04/25/regular-expression-dos-weaknesses-in-crs/
 ---
 
 

--- a/content/blog/2019-05-01-crs-project-news-may-2019.md
+++ b/content/blog/2019-05-01-crs-project-news-may-2019.md
@@ -8,7 +8,6 @@ tags:
   - DoS
   - ReDoS
 title: CRS Project News May 2019
-url: /2019/05/01/crs-project-news-may-2019/
 ---
 
 

--- a/content/blog/2019-06-27-announcement-owasp-modsecurity-core-rule-set-version-3-1-1.md
+++ b/content/blog/2019-06-27-announcement-owasp-modsecurity-core-rule-set-version-3-1-1.md
@@ -4,7 +4,6 @@ categories:
   - Blog
 date: '2019-06-27T06:32:41+02:00'
 title: 'Announcement: OWASP ModSecurity Core Rule Set Version 3.1.1'
-url: /2019/06/27/announcement-owasp-modsecurity-core-rule-set-version-3-1-1/
 ---
 
 

--- a/content/blog/2019-08-07-crs-project-news-august-2019.md
+++ b/content/blog/2019-08-07-crs-project-news-august-2019.md
@@ -6,7 +6,6 @@ date: '2019-08-07T22:45:43+02:00'
 tags:
   - CRS-News
 title: CRS Project News August 2019
-url: /2019/08/07/crs-project-news-august-2019/
 ---
 
 

--- a/content/blog/2019-08-26-optimizing-regular-expressions.md
+++ b/content/blog/2019-08-26-optimizing-regular-expressions.md
@@ -4,7 +4,6 @@ categories:
   - Blog
 date: '2019-08-26T10:44:51+02:00'
 title: How the CRS optimizes regular expressions
-url: /2019/08/26/optimizing-regular-expressions/
 ---
 
 

--- a/content/blog/2019-09-03-announcement-owasp-modsecurity-core-rule-set-version-3-2-0-rc2.md
+++ b/content/blog/2019-09-03-announcement-owasp-modsecurity-core-rule-set-version-3-2-0-rc2.md
@@ -7,7 +7,6 @@ tags:
   - '3.2'
   - Release
 title: 'Announcement: OWASP ModSecurity Core Rule Set Version 3.2.0-RC2'
-url: /2019/09/03/announcement-owasp-modsecurity-core-rule-set-version-3-2-0-rc2/
 ---
 
 

--- a/content/blog/2019-09-09-how-the-crs-protects-the-vulnerable-web-application-pixi-by-owasp-devslop.md
+++ b/content/blog/2019-09-09-how-the-crs-protects-the-vulnerable-web-application-pixi-by-owasp-devslop.md
@@ -6,7 +6,6 @@ date: '2019-09-09T10:37:38+02:00'
 tags:
   - DevSlop
 title: How the CRS protects the vulnerable web application Pixi by OWASP DevSlop
-url: /2019/09/09/how-the-crs-protects-the-vulnerable-web-application-pixi-by-owasp-devslop/
 ---
 
 

--- a/content/blog/2019-09-24-owasp-modsecurity-core-rule-set-version-3-2-0.md
+++ b/content/blog/2019-09-24-owasp-modsecurity-core-rule-set-version-3-2-0.md
@@ -4,7 +4,6 @@ categories:
   - Blog
 date: '2019-09-24T11:13:43+02:00'
 title: 'Announcement: OWASP ModSecurity Core Rule Set Version 3.2.0'
-url: /2019/09/24/owasp-modsecurity-core-rule-set-version-3-2-0/
 ---
 
 

--- a/content/blog/2019-09-26-running-a-few-dozens-of-new-magic-xss-payloads-against-crs-3-2.md
+++ b/content/blog/2019-09-26-running-a-few-dozens-of-new-magic-xss-payloads-against-crs-3-2.md
@@ -4,7 +4,6 @@ categories:
   - Blog
 date: '2019-09-26T23:59:23+02:00'
 title: Running a few dozens of new magic XSS payloads against CRS 3.2
-url: /2019/09/26/running-a-few-dozens-of-new-magic-xss-payloads-against-crs-3-2/
 ---
 
 

--- a/content/blog/2020-01-14-crs-project-news-january-2020.md
+++ b/content/blog/2020-01-14-crs-project-news-january-2020.md
@@ -6,7 +6,6 @@ date: '2020-01-14T08:12:50+01:00'
 tags:
   - CRS-News
 title: CRS Project News January 2020
-url: /2020/01/14/crs-project-news-january-2020/
 ---
 
 

--- a/content/blog/2020-01-18-cve-2019-19886-high-dos-against-libmodsecurity-3.md
+++ b/content/blog/2020-01-18-cve-2019-19886-high-dos-against-libmodsecurity-3.md
@@ -7,7 +7,6 @@ tags:
   - ModSecurity
   - security
 title: CVE-2019-19886 - HIGH - DoS against libModSecurity 3
-url: /2020/01/18/cve-2019-19886-high-dos-against-libmodsecurity-3/
 ---
 
 

--- a/content/blog/2020-05-13-crs-repository-at-new-location.md
+++ b/content/blog/2020-05-13-crs-repository-at-new-location.md
@@ -4,7 +4,6 @@ categories:
   - Blog
 date: '2020-05-13T22:12:06+02:00'
 title: CRS Repository at New Location
-url: /2020/05/13/crs-repository-at-new-location/
 ---
 
 We have successfully migrated our GitHub repository to a new location at  

--- a/content/blog/2020-05-27-owasp-modsecurity-core-rule-set-v3-3-0-release-candidate-1-available.md
+++ b/content/blog/2020-05-27-owasp-modsecurity-core-rule-set-v3-3-0-release-candidate-1-available.md
@@ -6,7 +6,6 @@ date: '2020-05-27T16:05:24+02:00'
 tags:
   - Release
 title: OWASP ModSecurity Core Rule Set v3.3.0 Release Candidate 1 available
-url: /2020/05/27/owasp-modsecurity-core-rule-set-v3-3-0-release-candidate-1-available/
 ---
 
 

--- a/content/blog/2020-06-08-overhauling-the-crs-tags.md
+++ b/content/blog/2020-06-08-overhauling-the-crs-tags.md
@@ -7,7 +7,6 @@ tags:
   - CAPEC
   - Tagging
 title: Overhauling the CRS Tags
-url: /2020/06/08/overhauling-the-crs-tags/
 ---
 
 

--- a/content/blog/2020-06-18-owasp-modsecurity-core-rule-set-v3-3-0-release-candidate-2-available.md
+++ b/content/blog/2020-06-18-owasp-modsecurity-core-rule-set-v3-3-0-release-candidate-2-available.md
@@ -4,7 +4,6 @@ categories:
   - Blog
 date: '2020-06-18T20:39:56+02:00'
 title: OWASP ModSecurity Core Rule Set v3.3.0 Release Candidate 2 available
-url: /2020/06/18/owasp-modsecurity-core-rule-set-v3-3-0-release-candidate-2-available/
 ---
 
 

--- a/content/blog/2020-07-01-owasp-modsecurity-core-rule-set-v3-3-0-available.md
+++ b/content/blog/2020-07-01-owasp-modsecurity-core-rule-set-v3-3-0-available.md
@@ -6,7 +6,6 @@ date: '2020-07-01T20:26:37+02:00'
 tags:
   - Release
 title: OWASP ModSecurity Core Rule Set v3.3.0 available
-url: /2020/07/01/owasp-modsecurity-core-rule-set-v3-3-0-available/
 ---
 
 

--- a/content/blog/2020-09-01-introducing-msc_pyparser.md
+++ b/content/blog/2020-09-01-introducing-msc_pyparser.md
@@ -4,7 +4,6 @@ categories:
   - Blog
 date: '2020-09-01T13:35:59+02:00'
 title: Introducing msc_pyparser
-url: /2020/09/01/introducing-msc_pyparser/
 ---
 
 

--- a/content/blog/2020-09-14-cve-2020-15598.md
+++ b/content/blog/2020-09-14-cve-2020-15598.md
@@ -10,7 +10,6 @@ tags:
   - DoS
   - ModSecurity
 title: CVE-2020-15598 &#8211; ModSecurity v3 Affected By DoS (Severity HIGH)
-url: /2020/09/14/cve-2020-15598/
 ---
 
 

--- a/content/blog/2020-12-28-owasp-modsecurity-core-rule-set-v3-3-1-release-candidate-1-available.md
+++ b/content/blog/2020-12-28-owasp-modsecurity-core-rule-set-v3-3-1-release-candidate-1-available.md
@@ -4,7 +4,6 @@ categories:
   - Blog
 date: '2020-12-28T18:38:16+01:00'
 title: OWASP ModSecurity Core Rule Set v3.3.1 Release Candidate 1 available
-url: /2020/12/28/owasp-modsecurity-core-rule-set-v3-3-1-release-candidate-1-available/
 ---
 
 

--- a/content/blog/2021-01-06-introducing-msc_retest.md
+++ b/content/blog/2021-01-06-introducing-msc_retest.md
@@ -9,7 +9,6 @@ tags:
   - msc_retest
   - performance
 title: Introducing msc_retest
-url: /2021/01/06/introducing-msc_retest/
 ---
 
 Debugging CRS and more generally debugging ModSecurity can be nasty. False Positives are the worst, but also nagging performance problems can spoil the fun. Sometimes you have network problems or the whole architecture is botched. But equally often it's simply your server or ModSecurity that's misbehaving.

--- a/content/blog/2021-03-02-disabling-request-body-access-in-modsecurity-3-leads-to-complete-bypass.md
+++ b/content/blog/2021-03-02-disabling-request-body-access-in-modsecurity-3-leads-to-complete-bypass.md
@@ -10,7 +10,6 @@ tags:
   - SecRequestBodyAccess
   - security
 title: Disabling Request Body Access in ModSecurity 3 Leads to Complete Bypass
-url: /2021/03/02/disabling-request-body-access-in-modsecurity-3-leads-to-complete-bypass/
 ---
 
 

--- a/content/blog/2021-03-05-announcing-a-partnership-with-nginx.md
+++ b/content/blog/2021-03-05-announcing-a-partnership-with-nginx.md
@@ -4,7 +4,6 @@ categories:
   - Blog
 date: '2021-03-05T14:57:47+01:00'
 title: Announcing a partnership with NGINX
-url: /2021/03/05/announcing-a-partnership-with-nginx/
 ---
 
 

--- a/content/blog/2021-04-14-introducing-the-dev-on-duty-program.md
+++ b/content/blog/2021-04-14-introducing-the-dev-on-duty-program.md
@@ -4,7 +4,6 @@ categories:
   - Blog
 date: '2021-04-14T10:03:45+02:00'
 title: Introducing the Dev on Duty Program
-url: /2021/04/14/introducing-the-dev-on-duty-program/
 ---
 
 

--- a/content/blog/2021-05-19-a-new-attempt-to-combine-the-crs-with-machine-learning.md
+++ b/content/blog/2021-05-19-a-new-attempt-to-combine-the-crs-with-machine-learning.md
@@ -8,7 +8,6 @@ tags:
   - machinelearning
   - ML
 title: A new attempt to combine the CRS with machine learning
-url: /2021/05/19/a-new-attempt-to-combine-the-crs-with-machine-learning/
 ---
 
 *The following is a contributing blog post by Floriane Gilliéron. You can reach Floriane via firstname dot lastname at gmail.com.*

--- a/content/blog/2021-06-28-upcoming-crs-security-releases.md
+++ b/content/blog/2021-06-28-upcoming-crs-security-releases.md
@@ -4,7 +4,6 @@ categories:
   - Blog
 date: '2021-06-28T15:49:11+02:00'
 title: Upcoming CRS Security Releases
-url: /2021/06/28/upcoming-crs-security-releases/
 ---
 
 A security problem with the OWASP ModSecurity Core Rule Set has been brought to our attention recently. The CRS team is now working on a fix that will be released on Wednesday as 3.1.2, 3.2.1 and 3.3.2.  

--- a/content/blog/2021-06-30-cve-2021-35368-crs-request-body-bypass.md
+++ b/content/blog/2021-06-30-cve-2021-35368-crs-request-body-bypass.md
@@ -10,7 +10,6 @@ tags:
   - v3.2.1
   - v3.3.2
 title: CVE-2021-35368 &#8211; CRS Request Body Bypass (Update)
-url: /2021/06/30/cve-2021-35368-crs-request-body-bypass/
 ---
 
 There is a severe security issue in our rule set. It has been present since the release of CRS 3.1.0 and was recently brought to our attention.

--- a/content/blog/2021-10-06-crs-protecting-users-from-apache-cve-2021-41773.md
+++ b/content/blog/2021-10-06-crs-protecting-users-from-apache-cve-2021-41773.md
@@ -4,7 +4,6 @@ categories:
   - Blog
 date: '2021-10-06T08:40:42+02:00'
 title: CRS protecting users from Apache CVE-2021-41773
-url: /2021/10/06/crs-protecting-users-from-apache-cve-2021-41773/
 ---
 
 Version 2.4.49 of the Apache webserver is affected by a path traversal vulnerability. This caught a lot of people on the left foot. Well not those who protect their services with CRS. CRS has your back for this new exploit too - as very often.  

--- a/content/blog/2021-10-28-working-with-paranoia-levels.md
+++ b/content/blog/2021-10-28-working-with-paranoia-levels.md
@@ -6,7 +6,6 @@ date: '2021-10-28T20:54:15+02:00'
 tags:
   - Paranoia Levels
 title: Working with Paranoia Levels
-url: /2021/10/28/working-with-paranoia-levels/
 ---
 
 

--- a/content/blog/2021-11-01-crs-developer-retreat-2021.md
+++ b/content/blog/2021-11-01-crs-developer-retreat-2021.md
@@ -4,7 +4,6 @@ categories:
   - Blog
 date: '2021-11-01T11:42:19+01:00'
 title: CRS Developer Retreat 2021
-url: /2021/11/01/crs-developer-retreat-2021/
 ---
 
 

--- a/content/blog/2021-12-09-introducing-the-crs-sandbox.md
+++ b/content/blog/2021-12-09-introducing-the-crs-sandbox.md
@@ -4,7 +4,6 @@ categories:
   - Blog
 date: '2021-12-09T12:54:13+01:00'
 title: Introducing the CRS Sandbox
-url: /2021/12/09/introducing-the-crs-sandbox/
 ---
 
 

--- a/content/blog/2021-12-13-crs-and-log4j-log4shell-cve-2021-44228.md
+++ b/content/blog/2021-12-13-crs-and-log4j-log4shell-cve-2021-44228.md
@@ -8,7 +8,6 @@ tags:
   - log4j
   - log4shell
 title: CRS and Log4j / Log4Shell / CVE-2021-44228
-url: /2021/12/13/crs-and-log4j-log4shell-cve-2021-44228/
 ---
 
 

--- a/content/blog/2021-12-16-public-hunt-for-log4j-log4shell-evasions-waf-bypasses.md
+++ b/content/blog/2021-12-16-public-hunt-for-log4j-log4shell-evasions-waf-bypasses.md
@@ -4,7 +4,6 @@ categories:
   - Blog
 date: '2021-12-16T13:01:59+01:00'
 title: Public Hunt for log4j / log4shell Evasions / WAF Bypasses
-url: /2021/12/16/public-hunt-for-log4j-log4shell-evasions-waf-bypasses/
 ---
 
 

--- a/content/blog/2021-12-22-talking-about-modsecurity-and-the-new-coraza-waf.md
+++ b/content/blog/2021-12-22-talking-about-modsecurity-and-the-new-coraza-waf.md
@@ -4,7 +4,6 @@ categories:
   - Blog
 date: '2021-12-22T13:23:02+01:00'
 title: Talking about ModSecurity and the new Coraza WAF
-url: /2021/12/22/talking-about-modsecurity-and-the-new-coraza-waf/
 ---
 
 

--- a/content/blog/2022-01-12-crs-plugin-mechanism.md
+++ b/content/blog/2022-01-12-crs-plugin-mechanism.md
@@ -7,7 +7,6 @@ tags:
   - ModSecurity
   - Plugins
 title: The CRS Plugin Mechanism
-url: /2022/01/12/crs-plugin-mechanism/
 ---
 
 

--- a/content/blog/2022-01-20-comprehensive-view-of-the-waf-market-from-an-open-source-perspective.md
+++ b/content/blog/2022-01-20-comprehensive-view-of-the-waf-market-from-an-open-source-perspective.md
@@ -4,7 +4,6 @@ categories:
   - Blog
 date: '2022-01-20T14:46:29+01:00'
 title: Comprehensive View of the WAF Market From an Open Source Perspective
-url: /2022/01/20/comprehensive-view-of-the-waf-market-from-an-open-source-perspective/
 ---
 
 

--- a/content/blog/2022-02-09-introducing-the-fake-bot-plugin.md
+++ b/content/blog/2022-02-09-introducing-the-fake-bot-plugin.md
@@ -8,7 +8,6 @@ tags:
   - Lua
   - Plugins
 title: Introducing the Fake Bot Plugin
-url: /2022/02/09/introducing-the-fake-bot-plugin/
 ---
 
 

--- a/content/blog/2022-03-02-the-case-for-early-blocking.md
+++ b/content/blog/2022-03-02-the-case-for-early-blocking.md
@@ -6,7 +6,6 @@ date: '2022-03-02T08:43:01+01:00'
 tags:
   - Early Blocking
 title: The Case for Early Blocking
-url: /2022/03/02/the-case-for-early-blocking/
 ---
 
 

--- a/content/blog/2022-03-08-crs-names-felipe-zipitria-as-third-co-lead.md
+++ b/content/blog/2022-03-08-crs-names-felipe-zipitria-as-third-co-lead.md
@@ -7,7 +7,6 @@ tags:
   - CRS-News
   - Felipe Zipitria
 title: CRS names Felipe Zipitría as third Co-Lead
-url: /2022/03/08/crs-names-felipe-zipitria-as-third-co-lead/
 ---
 
 

--- a/content/blog/2022-04-28-coreruleset-v4-rc1-available.md
+++ b/content/blog/2022-04-28-coreruleset-v4-rc1-available.md
@@ -4,7 +4,6 @@ categories:
   - Blog
 date: '2022-04-28T21:20:10+02:00'
 title: Core Rule Set v4.0.0 Release Candidate 1 available
-url: /2022/04/28/coreruleset-v4-rc1-available/
 ---
 
 

--- a/content/blog/2022-07-11-update-on-crs-4-0-release-delay.md
+++ b/content/blog/2022-07-11-update-on-crs-4-0-release-delay.md
@@ -4,7 +4,6 @@ categories:
   - Blog
 date: '2022-07-11T12:40:38+02:00'
 title: Update on CRS 4.0 release delay
-url: /2022/07/11/update-on-crs-4-0-release-delay/
 ---
 
 

--- a/content/blog/2022-09-19-crs-version-3-3-3-and-3-2-2-covering-several-cves.md
+++ b/content/blog/2022-09-19-crs-version-3-3-3-and-3-2-2-covering-several-cves.md
@@ -4,7 +4,6 @@ categories:
   - Blog
 date: '2022-09-19T16:08:09+02:00'
 title: CRS Version 3.3.3 and 3.2.2 (covering several CVEs)
-url: /2022/09/19/crs-version-3-3-3-and-3-2-2-covering-several-cves/
 ---
 
 

--- a/content/blog/2022-09-20-crs-version-3-3-4-and-3-2-3.md
+++ b/content/blog/2022-09-20-crs-version-3-3-4-and-3-2-3.md
@@ -4,7 +4,6 @@ categories:
   - Blog
 date: '2022-09-20T18:28:19+02:00'
 title: CRS Version 3.3.4 and 3.2.3 fix a regression
-url: /2022/09/20/crs-version-3-3-4-and-3-2-3/
 ---
 
 

--- a/content/blog/2022-10-18-meet-the-crs-team-andrea-the-musical-man-in-the-middle.md
+++ b/content/blog/2022-10-18-meet-the-crs-team-andrea-the-musical-man-in-the-middle.md
@@ -6,7 +6,6 @@ date: '2022-10-18T15:37:21+02:00'
 tags:
   - developer portrait
 title: 'Meet the CRS team: Andrea, the musical man-in-the-middle'
-url: /2022/10/18/meet-the-crs-team-andrea-the-musical-man-in-the-middle/
 ---
 
 

--- a/content/blog/2022-11-22-meet-the-crs-team-ervin-the-gardening-radio-amateur-in-the-background.md
+++ b/content/blog/2022-11-22-meet-the-crs-team-ervin-the-gardening-radio-amateur-in-the-background.md
@@ -6,7 +6,6 @@ date: '2022-11-22T22:03:47+01:00'
 tags:
   - developer portrait
 title: 'Meet the CRS team: Ervin, the gardening radio amateur in the background'
-url: /2022/11/22/meet-the-crs-team-ervin-the-gardening-radio-amateur-in-the-background/
 ---
 
 

--- a/content/blog/2022-12-01-the-crs-developer-retreat-2022.md
+++ b/content/blog/2022-12-01-the-crs-developer-retreat-2022.md
@@ -4,7 +4,6 @@ categories:
   - Blog
 date: '2022-12-01T08:13:00+01:00'
 title: The CRS Developer Retreat 2022
-url: /2022/12/01/the-crs-developer-retreat-2022/
 ---
 
 

--- a/content/blog/2022-12-08-bug-bounty-switzerland-supports-crs-as-silver-sponsor.md
+++ b/content/blog/2022-12-08-bug-bounty-switzerland-supports-crs-as-silver-sponsor.md
@@ -4,7 +4,6 @@ categories:
   - Blog
 date: '2022-12-08T02:22:12+01:00'
 title: Bug Bounty Switzerland supports CRS as Silver sponsor
-url: /2022/12/08/bug-bounty-switzerland-supports-crs-as-silver-sponsor/
 ---
 
 

--- a/content/blog/2022-12-09-save-the-date-crs-community-summit-on-february-14-2023.md
+++ b/content/blog/2022-12-09-save-the-date-crs-community-summit-on-february-14-2023.md
@@ -4,7 +4,6 @@ categories:
   - Blog
 date: '2022-12-09T02:45:28+01:00'
 title: 'Save the Date: CRS Community Summit on February 14, 2023'
-url: /2022/12/09/save-the-date-crs-community-summit-on-february-14-2023/
 ---
 
 

--- a/content/blog/2022-12-12-microsoft-supports-crs-as-gold-sponsor.md
+++ b/content/blog/2022-12-12-microsoft-supports-crs-as-gold-sponsor.md
@@ -7,7 +7,6 @@ tags:
   - CRS-News
   - sponsoring
 title: Microsoft Supports CRS as Gold sponsor
-url: /2022/12/12/microsoft-supports-crs-as-gold-sponsor/
 ---
 
 

--- a/content/blog/2023-01-17-meet-the-crs-team-franzi-the-puzzle-loving-hard-worker-with-a-mission.md
+++ b/content/blog/2023-01-17-meet-the-crs-team-franzi-the-puzzle-loving-hard-worker-with-a-mission.md
@@ -6,7 +6,6 @@ date: '2023-01-17T18:54:57+01:00'
 tags:
   - developer portrait
 title: 'Meet the CRS team: Fränzi, the puzzle-loving hard worker with a mission'
-url: /2023/01/17/meet-the-crs-team-franzi-the-puzzle-loving-hard-worker-with-a-mission/
 ---
 
 

--- a/content/blog/2023-01-19-registration-for-the-owasp-crs-community-summit-2023-dublin-feb-14.md
+++ b/content/blog/2023-01-19-registration-for-the-owasp-crs-community-summit-2023-dublin-feb-14.md
@@ -4,7 +4,6 @@ categories:
   - Blog
 date: '2023-01-19T14:52:50+01:00'
 title: Registration for the OWASP CRS Community Summit 2023 - Dublin, Feb 14
-url: /2023/01/19/registration-for-the-owasp-crs-community-summit-2023-dublin-feb-14/
 ---
 
 

--- a/content/blog/2023-02-02-crs-welcomes-edgio-as-gold-sponsor.md
+++ b/content/blog/2023-02-02-crs-welcomes-edgio-as-gold-sponsor.md
@@ -4,7 +4,6 @@ categories:
   - Blog
 date: '2023-02-02T17:22:21+01:00'
 title: CRS Welcomes Edgio as Gold Sponsor
-url: /2023/02/02/crs-welcomes-edgio-as-gold-sponsor/
 ---
 
 

--- a/content/blog/2023-02-22-a-new-rule-to-prevent-sql-in-json.md
+++ b/content/blog/2023-02-22-a-new-rule-to-prevent-sql-in-json.md
@@ -4,7 +4,6 @@ categories:
   - Blog
 date: '2023-02-22T22:01:07+01:00'
 title: A new rule to prevent SQL in JSON
-url: /2023/02/22/a-new-rule-to-prevent-sql-in-json/
 ---
 
 

--- a/content/blog/2023-05-03-a-brief-report-on-the-crs-community-summit-2023.md
+++ b/content/blog/2023-05-03-a-brief-report-on-the-crs-community-summit-2023.md
@@ -4,7 +4,6 @@ categories:
   - Blog
 date: '2023-05-03T15:43:13+02:00'
 title: A brief report on the CRS Community Summit 2023.
-url: /2023/05/03/a-brief-report-on-the-crs-community-summit-2023/
 ---
 
 

--- a/content/blog/2023-05-09-what-we-learnt-from-our-bug-bounty-program-its-not-for-the-faint-of-heart.md
+++ b/content/blog/2023-05-09-what-we-learnt-from-our-bug-bounty-program-its-not-for-the-faint-of-heart.md
@@ -4,7 +4,6 @@ categories:
   - Blog
 date: '2023-05-09T09:00:00+02:00'
 title: 'What we learnt from our bug bounty program: It&#8217;s not for the faint of heart'
-url: /2023/05/09/what-we-learnt-from-our-bug-bounty-program-its-not-for-the-faint-of-heart/
 ---
 
 

--- a/content/blog/2023-05-27-follow-the-crs-project-on-youtube.md
+++ b/content/blog/2023-05-27-follow-the-crs-project-on-youtube.md
@@ -4,7 +4,6 @@ categories:
   - Blog
 date: '2023-05-27T10:42:01+02:00'
 title: Follow the CRS project on YouTube
-url: /2023/05/27/follow-the-crs-project-on-youtube/
 ---
 
 

--- a/content/blog/2023-07-17-cve-2023-38199-multiple-content-type-headers.md
+++ b/content/blog/2023-07-17-cve-2023-38199-multiple-content-type-headers.md
@@ -8,7 +8,6 @@ tags:
   - CVE-2023-38199
   - security
 title: CVE-2023-38199 – Multiple Content-Type Headers
-url: /2023/07/17/cve-2023-38199-multiple-content-type-headers/
 ---
 
 

--- a/content/blog/2023-07-24-crs-version-3-3-5-released.md
+++ b/content/blog/2023-07-24-crs-version-3-3-5-released.md
@@ -4,7 +4,6 @@ categories:
   - Blog
 date: '2023-07-24T20:11:27+02:00'
 title: CRS version 3.3.5 released
-url: /2023/07/24/crs-version-3-3-5-released/
 ---
 
 

--- a/content/blog/2023-08-02-libmodsecurity3-cve-2023-38285-affecting-crs-users.md
+++ b/content/blog/2023-08-02-libmodsecurity3-cve-2023-38285-affecting-crs-users.md
@@ -6,7 +6,6 @@ date: '2023-08-02T15:45:05+02:00'
 tags:
   - libmodsecurity3 cve-2023-38285
 title: libmodsecurity3 CVE-2023-38285 affecting CRS users
-url: /2023/08/02/libmodsecurity3-cve-2023-38285-affecting-crs-users/
 ---
 
 

--- a/content/blog/2023-09-21-crs-performance-framework-a-gsoc-2023-project.md
+++ b/content/blog/2023-09-21-crs-performance-framework-a-gsoc-2023-project.md
@@ -4,7 +4,6 @@ categories:
   - Blog
 date: '2023-09-21T13:05:47+02:00'
 title: CRS Performance Framework - A GSoC 2023 Project
-url: /2023/09/21/crs-performance-framework-a-gsoc-2023-project/
 ---
 
 This year, the OWASP ModSecurity Core Rule Set for the second time took part in the Google Summer of Code initiative. Google Summer of Code (GSoC) is a global online program focused on bringing new contributors into open-source software development. GSoC contributors work with an open-source organization of their choice on a 12+ week programming project under the guidance of the mentors from the organization. [Dexter Chang](https://github.com/dextermallo) had applied to the CRS project with a proposal for a performance framework. We spoke to Dexter about his GSoC experience with the Core Rule Set.

--- a/content/blog/2023-10-26-crs-version-4-0-0-release-candidate-2-available.md
+++ b/content/blog/2023-10-26-crs-version-4-0-0-release-candidate-2-available.md
@@ -4,7 +4,6 @@ categories:
   - Blog
 date: '2023-10-26T22:42:38+02:00'
 title: CRS version 4.0.0 release candidate 2 available
-url: /2023/10/26/crs-version-4-0-0-release-candidate-2-available/
 ---
 
 

--- a/content/blog/2023-11-05-universe-domination-plans-in-budapest-the-crs-developer-retreat-2023-day-1.md
+++ b/content/blog/2023-11-05-universe-domination-plans-in-budapest-the-crs-developer-retreat-2023-day-1.md
@@ -4,7 +4,6 @@ categories:
   - Blog
 date: '2023-11-05T20:18:00+01:00'
 title: Universe domination plans in Budapest - The CRS Developer Retreat 2023, day 1 
-url: /2023/11/05/universe-domination-plans-in-budapest-the-crs-developer-retreat-2023-day-1/
 ---
 
 

--- a/content/blog/2023-11-09-meet-the-crs-team-andrew-the-technical-writer-who-loves-eurovision-and-doom-ii.md
+++ b/content/blog/2023-11-09-meet-the-crs-team-andrew-the-technical-writer-who-loves-eurovision-and-doom-ii.md
@@ -6,7 +6,6 @@ date: '2023-11-09T18:03:48+01:00'
 tags:
   - developer portrait
 title: 'Meet the CRS team: Andrew, the technical writer who loves Eurovision and Doom II'
-url: /2023/11/09/meet-the-crs-team-andrew-the-technical-writer-who-loves-eurovision-and-doom-ii/
 ---
 
 #### *When invited to join the Core Rule Set project, Andrew Howe felt a bit intimidated by the highly talented team at first. Today he is a valued member of the CRS core team, bringing his experience as a technical writer and a CRS integrator. “Having people onboard with experience of running CRS at a large-scale would be very useful,” he says. What else he said, you can read in this interview.*

--- a/content/blog/2023-11-28-discussions-excursions-and-hard-work-crs-developer-retreat-2023-days-2-7.md
+++ b/content/blog/2023-11-28-discussions-excursions-and-hard-work-crs-developer-retreat-2023-days-2-7.md
@@ -4,7 +4,6 @@ categories:
   - Blog
 date: '2023-11-28T07:00:00+01:00'
 title: Discussions, excursions and hard work – CRS Developer Retreat 2023, days 2–7
-url: /2023/11/28/discussions-excursions-and-hard-work-crs-developer-retreat-2023-days-2-7/
 ---
 
 

--- a/content/blog/2023-11-30-meet-the-crs-team-felipe-the-team-player-on-the-other-side-of-the-atlantic.md
+++ b/content/blog/2023-11-30-meet-the-crs-team-felipe-the-team-player-on-the-other-side-of-the-atlantic.md
@@ -6,7 +6,6 @@ date: '2023-11-30T06:00:00+01:00'
 tags:
   - developer portrait
 title: 'Meet the CRS team: Felipe, the team player on the other side of the Atlantic'
-url: /2023/11/30/meet-the-crs-team-felipe-the-team-player-on-the-other-side-of-the-atlantic/
 ---
 
 

--- a/content/blog/2024-01-11-a-new-silver-sponsor-for-crs-swiss-post.md
+++ b/content/blog/2024-01-11-a-new-silver-sponsor-for-crs-swiss-post.md
@@ -4,7 +4,6 @@ categories:
   - Blog
 date: '2024-01-11T11:30:15+01:00'
 title: 'A new silver sponsor for CRS: Swiss Post'
-url: /2024/01/11/a-new-silver-sponsor-for-crs-swiss-post/
 ---
 
 

--- a/content/blog/2024-01-15-welcome-the-newest-addition-to-the-owasp-family-modsecurity.md
+++ b/content/blog/2024-01-15-welcome-the-newest-addition-to-the-owasp-family-modsecurity.md
@@ -4,7 +4,6 @@ categories:
   - Blog
 date: '2024-01-15T13:32:16+01:00'
 title: 'Welcome the newest addition to the OWASP family: ModSecurity!'
-url: /2024/01/15/welcome-the-newest-addition-to-the-owasp-family-modsecurity/
 ---
 
 

--- a/content/blog/2024-02-14-let-crs-4-be-your-valentine.md
+++ b/content/blog/2024-02-14-let-crs-4-be-your-valentine.md
@@ -8,7 +8,6 @@ tags:
   - Plugins
   - Release
 title: Let CRS 4 be your valentine!
-url: /2024/02/14/let-crs-4-be-your-valentine/
 ---
 
 

--- a/content/blog/2024-02-18-the-owasp-crs-project-mourns-the-death-of-co-leader-walter-hop.md
+++ b/content/blog/2024-02-18-the-owasp-crs-project-mourns-the-death-of-co-leader-walter-hop.md
@@ -4,7 +4,6 @@ categories:
   - Blog
 date: '2024-02-18T17:22:23+01:00'
 title: The OWASP CRS project mourns the death of Co-Leader Walter Hop
-url: /2024/02/18/the-owasp-crs-project-mourns-the-death-of-co-leader-walter-hop/
 ---
 
 

--- a/content/blog/2024-02-27-new-feature-spotlight-early-blocking.md
+++ b/content/blog/2024-02-27-new-feature-spotlight-early-blocking.md
@@ -2,7 +2,6 @@
 title: 'New feature spotlight: Early Blocking'
 date: '2024-02-27T09:00:00+01:00'
 author: dune73
-url: /2024/02/27/new-feature-spotlight-early-blocking/
 categories:
     - Blog
 tags:

--- a/content/blog/2024-03-27-crs-version-4-1-0-released.md
+++ b/content/blog/2024-03-27-crs-version-4-1-0-released.md
@@ -2,7 +2,6 @@
 title: 'CRS version 4.1.0 released'
 date: '2024-03-27T15:03:22+01:00'
 author: amonachesi
-permalink: /2024/03/27/crs-version-4-1-0-released/
 categories:
     - Blog
 tags:

--- a/content/blog/2024-04-04-save-the-date-crs-community-summit-on-june-26-in-lisbon.md
+++ b/content/blog/2024-04-04-save-the-date-crs-community-summit-on-june-26-in-lisbon.md
@@ -2,7 +2,6 @@
 title: 'Save the date: CRS Community Summit on June 26 in Lisbon'
 date: '2024-04-04T14:22:35+02:00'
 author: amonachesi
-url: /2024/04/04/save-the-date-crs-community-summit-on-june-26-in-lisbon/
 categories:
     - Blog
 ---


### PR DESCRIPTION
Turns out if the `url:` is defined in the front matter, it will be used over the permalink.

Updating the permalink and removing the url generates the same urls as before.