### PR TITLE
fix: edit link in footer

### DIFF
--- a/layouts/partials/footer/github.html
+++ b/layouts/partials/footer/github.html
@@ -1,0 +1,13 @@
+{{ with .Site.Params.github }}
+{{ if and .repo_url .show_edit_link }}
+{{ with $.File }}
+{{ $pageRelPath := replace .Path "\\" "/" }}
+{{ $editURL := printf "%s/content/%s" $.Site.Params.github.repo_url $pageRelPath }}
+
+<a target="_blank" rel="noopener noreferrer" href="{{ $editURL }}" class="nowrap">
+    {{ $.Site.Params.github_edit | default "Edit this page on GitHub" }}
+</a>
+
+{{ end }}
+{{ end }}
+{{ end }}


### PR DESCRIPTION
Edit link from GH points to the language version e.g. /en/<post> instead of just `<post>`. This fixes it.