### PR TITLE
feat: add links to supported major versions

### DIFF
--- a/config/_default/params.yaml
+++ b/config/_default/params.yaml
@@ -12,7 +12,9 @@ custom_css: []
 images: ["/img/social-share.png"]
 
 crs:
-  latest_version: "4.1.0"
+  release_url_prefix: "https://github.com/coreruleset/coreruleset/releases/tag"
+  latest_major_version: "4.1.0"
+  prev_major_version: "3.3.5"
 
 github:
   repo_url: "https://github.com/coreruleset/website/blob/main"

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -1,4 +1,5 @@
 {{ define "main" }}
+  {{- $crs := $.Site.Params.crs -}}
   <div class="columns hero-grid">
     <div class="hero-grid__col1">
       <h1 class="title">
@@ -8,6 +9,11 @@
       <h2 class="subhero">{{ i18n "subhero" }}</h2>
 
       <p class="shortened-width">{{ i18n "explainerText" | markdownify }}</p>
+
+      {{ with $crs }}
+      <a href="{{ printf "%s/v%s" .release_url_prefix .latest_major_version }}" class="button">Get latest: {{ .latest_major_version }}</a>
+      <a href="{{ printf "%s/v%s" .release_url_prefix .prev_major_version }}" class="button">Get previous major: {{ .prev_major_version }}</a>
+      {{ end }}
     </div>
     <div class="hero-grid__col2">
       <img
@@ -27,7 +33,7 @@
     <div class="card">
       <h2>{{ i18n "sectionTitle1" }}</h2>
       <p>{{ i18n "sectionText1" | markdownify }}</p>
-      <a href="https://github.com/coreruleset/coreruleset/releases/tag/v{{ .Site.Params.crs.latest_version }}" class="button">{{ i18n "sectionButton1" }}</a>
+      <a href="{{ printf "%s/v%s" $crs.release_url_prefix $crs.latest_major_version }}" class="button">{{ i18n "sectionButton1" }}</a>
     </div>
 
     <div class="card">


### PR DESCRIPTION
Right now this looks like:

<img width="660" alt="image" src="https://github.com/coreruleset/website/assets/3012076/b89bda8c-22a2-4294-8130-ce3e8c55394b">
