### PR TITLE
fix: update slug

### DIFF
--- a/content/blog/2017-08-10-modsecurity-version-2-9-2-released.md
+++ b/content/blog/2017-08-10-modsecurity-version-2-9-2-released.md
@@ -4,6 +4,7 @@ categories:
   - Blog
 date: '2017-08-10T12:48:47+02:00'
 title: ModSecurity version 2.9.2 released
+slug: 'modsecurity-version-2-9-2-released'
 ---
 
 Trustwave has released [ModSecurity version 2.9.2](https://www.trustwave.com/Resources/SpiderLabs-Blog/Announcing-ModSecurity-version-2-9-2/).

--- a/content/blog/2017-08-10-testing-wafs-ftw-version-1-0-released.md
+++ b/content/blog/2017-08-10-testing-wafs-ftw-version-1-0-released.md
@@ -4,6 +4,7 @@ categories:
   - Blog
 date: '2017-08-10T21:28:14+02:00'
 title: Testing WAFs, FTW Version 1.0 released
+slug: 'testing-wafs-ftw-version-1-0-released'
 ---
 
 

--- a/content/blog/2017-12-07-new-modsecurity-crs-courses-announced.md
+++ b/content/blog/2017-12-07-new-modsecurity-crs-courses-announced.md
@@ -4,6 +4,7 @@ categories:
   - Blog
 date: '2017-12-07T12:13:05+01:00'
 title: New ModSecurity / CRS Courses Announced
+slug: 'new-modsecurity-crs-courses-announced'
 ---
 
 

--- a/content/blog/2018-11-28-announcement-owasp-modsecurity-core-rule-set-version-3-1-0.md
+++ b/content/blog/2018-11-28-announcement-owasp-modsecurity-core-rule-set-version-3-1-0.md
@@ -4,6 +4,7 @@ categories:
   - Blog
 date: '2018-11-28T23:08:03+01:00'
 title: 'Announcement: OWASP ModSecurity Core Rule Set Version 3.1.0'
+slug: 'announcement-owasp-modsecurity-core-rule-set-version-3-1-0'
 ---
 
 

--- a/content/blog/2019-06-27-announcement-owasp-modsecurity-core-rule-set-version-3-1-1.md
+++ b/content/blog/2019-06-27-announcement-owasp-modsecurity-core-rule-set-version-3-1-1.md
@@ -4,6 +4,7 @@ categories:
   - Blog
 date: '2019-06-27T06:32:41+02:00'
 title: 'Announcement: OWASP ModSecurity Core Rule Set Version 3.1.1'
+slug: 'announcement-owasp-modsecurity-core-rule-set-version-3-1-1'
 ---
 
 

--- a/content/blog/2019-09-03-announcement-owasp-modsecurity-core-rule-set-version-3-2-0-rc2.md
+++ b/content/blog/2019-09-03-announcement-owasp-modsecurity-core-rule-set-version-3-2-0-rc2.md
@@ -7,6 +7,7 @@ tags:
   - '3.2'
   - Release
 title: 'Announcement: OWASP ModSecurity Core Rule Set Version 3.2.0-RC2'
+slug: 'owasp-modsecurity-core-rule-set-version-3-2-0'
 ---
 
 

--- a/content/blog/2019-09-24-owasp-modsecurity-core-rule-set-version-3-2-0.md
+++ b/content/blog/2019-09-24-owasp-modsecurity-core-rule-set-version-3-2-0.md
@@ -4,6 +4,7 @@ categories:
   - Blog
 date: '2019-09-24T11:13:43+02:00'
 title: 'Announcement: OWASP ModSecurity Core Rule Set Version 3.2.0'
+slug: 'owasp-modsecurity-core-rule-set-version-3-2-0'
 ---
 
 

--- a/content/blog/2019-09-26-running-a-few-dozens-of-new-magic-xss-payloads-against-crs-3-2.md
+++ b/content/blog/2019-09-26-running-a-few-dozens-of-new-magic-xss-payloads-against-crs-3-2.md
@@ -4,6 +4,7 @@ categories:
   - Blog
 date: '2019-09-26T23:59:23+02:00'
 title: Running a few dozens of new magic XSS payloads against CRS 3.2
+slug: 'running-a-few-dozens-of-new-magic-xss-payloads-against-crs-3-2'
 ---
 
 

--- a/content/blog/2020-05-27-owasp-modsecurity-core-rule-set-v3-3-0-release-candidate-1-available.md
+++ b/content/blog/2020-05-27-owasp-modsecurity-core-rule-set-v3-3-0-release-candidate-1-available.md
@@ -6,6 +6,7 @@ date: '2020-05-27T16:05:24+02:00'
 tags:
   - Release
 title: OWASP ModSecurity Core Rule Set v3.3.0 Release Candidate 1 available
+slug: 'owasp-modsecurity-core-rule-set-v3-3-0-release-candidate-1-available'
 ---
 
 

--- a/content/blog/2020-06-18-owasp-modsecurity-core-rule-set-v3-3-0-release-candidate-2-available.md
+++ b/content/blog/2020-06-18-owasp-modsecurity-core-rule-set-v3-3-0-release-candidate-2-available.md
@@ -4,6 +4,7 @@ categories:
   - Blog
 date: '2020-06-18T20:39:56+02:00'
 title: OWASP ModSecurity Core Rule Set v3.3.0 Release Candidate 2 available
+slug: 'owasp-modsecurity-core-rule-set-v3-3-0-release-candidate-2-available'
 ---
 
 

--- a/content/blog/2020-07-01-owasp-modsecurity-core-rule-set-v3-3-0-available.md
+++ b/content/blog/2020-07-01-owasp-modsecurity-core-rule-set-v3-3-0-available.md
@@ -6,6 +6,7 @@ date: '2020-07-01T20:26:37+02:00'
 tags:
   - Release
 title: OWASP ModSecurity Core Rule Set v3.3.0 available
+slug: 'owasp-modsecurity-core-rule-set-v3-3-0-available'
 ---
 
 

--- a/content/blog/2021-12-13-crs-and-log4j-log4shell-cve-2021-44228.md
+++ b/content/blog/2021-12-13-crs-and-log4j-log4shell-cve-2021-44228.md
@@ -8,7 +8,7 @@ tags:
   - log4j
   - log4shell
 title: CRS and Log4j / Log4Shell / CVE-2021-44228
-url: /20211213/crs-and-log4j-log4shell-cve-2021-44228/
+slug: 'crs-and-log4j-log4shell-cve-2021-44228'
 ---
 
 

--- a/content/blog/2021-12-16-public-hunt-for-log4j-log4shell-evasions-waf-bypasses.md
+++ b/content/blog/2021-12-16-public-hunt-for-log4j-log4shell-evasions-waf-bypasses.md
@@ -4,6 +4,7 @@ categories:
   - Blog
 date: '2021-12-16T13:01:59+01:00'
 title: Public Hunt for log4j / log4shell Evasions / WAF Bypasses
+slug: 'public-hunt-for-log4j-log4shell-evasions-waf-bypasses'
 ---
 
 

--- a/content/blog/2022-04-28-coreruleset-v4-rc1-available.md
+++ b/content/blog/2022-04-28-coreruleset-v4-rc1-available.md
@@ -4,6 +4,7 @@ categories:
   - Blog
 date: '2022-04-28T21:20:10+02:00'
 title: Core Rule Set v4.0.0 Release Candidate 1 available
+slug: 'coreruleset-v4-rc1-available'
 ---
 
 

--- a/content/blog/2022-07-11-update-on-crs-4-0-release-delay.md
+++ b/content/blog/2022-07-11-update-on-crs-4-0-release-delay.md
@@ -4,6 +4,7 @@ categories:
   - Blog
 date: '2022-07-11T12:40:38+02:00'
 title: Update on CRS 4.0 release delay
+slug: 'update-on-crs-4-0-release-delay'
 ---
 
 

--- a/content/blog/2022-09-19-crs-version-3-3-3-and-3-2-2-covering-several-cves.md
+++ b/content/blog/2022-09-19-crs-version-3-3-3-and-3-2-2-covering-several-cves.md
@@ -4,6 +4,7 @@ categories:
   - Blog
 date: '2022-09-19T16:08:09+02:00'
 title: CRS Version 3.3.3 and 3.2.2 (covering several CVEs)
+slug: 'crs-version-3-3-3-and-3-2-2-covering-several-cves'
 ---
 
 

--- a/content/blog/2022-09-20-crs-version-3-3-4-and-3-2-3.md
+++ b/content/blog/2022-09-20-crs-version-3-3-4-and-3-2-3.md
@@ -4,6 +4,7 @@ categories:
   - Blog
 date: '2022-09-20T18:28:19+02:00'
 title: CRS Version 3.3.4 and 3.2.3 fix a regression
+slug: 'crs-version-3-3-4-and-3-2-3'
 ---
 
 

--- a/content/blog/2023-07-24-crs-version-3-3-5-released.md
+++ b/content/blog/2023-07-24-crs-version-3-3-5-released.md
@@ -4,6 +4,7 @@ categories:
   - Blog
 date: '2023-07-24T20:11:27+02:00'
 title: CRS version 3.3.5 released
+slug: 'crs-version-3-3-5-released'
 ---
 
 

--- a/content/blog/2023-10-26-crs-version-4-0-0-release-candidate-2-available.md
+++ b/content/blog/2023-10-26-crs-version-4-0-0-release-candidate-2-available.md
@@ -4,6 +4,7 @@ categories:
   - Blog
 date: '2023-10-26T22:42:38+02:00'
 title: CRS version 4.0.0 release candidate 2 available
+slug: 'crs-version-4-0-0-release-candidate-2-available'
 ---
 
 

--- a/content/blog/2024-03-27-crs-version-4-1-0-released.md
+++ b/content/blog/2024-03-27-crs-version-4-1-0-released.md
@@ -7,6 +7,7 @@ categories:
 tags:
     - CRS-News
     - Release
+slug: 'crs-version-4-1-0-released'
 ---
 
 Last week, we have released CRS v4.1.0. The new release is the first according to the new monthly release schedule and brings a couple of new features and fixes.


### PR DESCRIPTION
How I'm doing this:

```
❯ ag -o '^title:.*\..*' *
2017-08-10-modsecurity-version-2-9-2-released.md
6:title: ModSecurity version 2.9.2 released

2017-08-10-testing-wafs-ftw-version-1-0-released.md
6:title: Testing WAFs, FTW Version 1.0 released

2018-11-28-announcement-owasp-modsecurity-core-rule-set-version-3-1-0.md
6:title: 'Announcement: OWASP ModSecurity Core Rule Set Version 3.1.0'

2019-06-27-announcement-owasp-modsecurity-core-rule-set-version-3-1-1.md
6:title: 'Announcement: OWASP ModSecurity Core Rule Set Version 3.1.1'

2019-09-03-announcement-owasp-modsecurity-core-rule-set-version-3-2-0-rc2.md
9:title: 'Announcement: OWASP ModSecurity Core Rule Set Version 3.2.0-RC2'

2019-09-24-owasp-modsecurity-core-rule-set-version-3-2-0.md
6:title: 'Announcement: OWASP ModSecurity Core Rule Set Version 3.2.0'

2019-09-26-running-a-few-dozens-of-new-magic-xss-payloads-against-crs-3-2.md
6:title: Running a few dozens of new magic XSS payloads against CRS 3.2

2020-05-27-owasp-modsecurity-core-rule-set-v3-3-0-release-candidate-1-available.md
8:title: OWASP ModSecurity Core Rule Set v3.3.0 Release Candidate 1 available

2020-06-18-owasp-modsecurity-core-rule-set-v3-3-0-release-candidate-2-available.md
6:title: OWASP ModSecurity Core Rule Set v3.3.0 Release Candidate 2 available

2020-07-01-owasp-modsecurity-core-rule-set-v3-3-0-available.md
8:title: OWASP ModSecurity Core Rule Set v3.3.0 available

2020-12-28-owasp-modsecurity-core-rule-set-v3-3-1-release-candidate-1-available.md
6:title: OWASP ModSecurity Core Rule Set v3.3.1 Release Candidate 1 available

2022-04-28-coreruleset-v4-rc1-available.md
6:title: Core Rule Set v4.0.0 Release Candidate 1 available

2022-07-11-update-on-crs-4-0-release-delay.md
6:title: Update on CRS 4.0 release delay

2022-09-19-crs-version-3-3-3-and-3-2-2-covering-several-cves.md
6:title: CRS Version 3.3.3 and 3.2.2 (covering several CVEs)

2022-09-20-crs-version-3-3-4-and-3-2-3.md
6:title: CRS Version 3.3.4 and 3.2.3 fix a regression

2023-05-03-a-brief-report-on-the-crs-community-summit-2023.md
6:title: A brief report on the CRS Community Summit 2023.

2023-07-24-crs-version-3-3-5-released.md
6:title: CRS version 3.3.5 released

2023-10-26-crs-version-4-0-0-release-candidate-2-available.md
6:title: CRS version 4.0.0 release candidate 2 available

2024-03-27-crs-version-4-1-0-released.md
2:title: 'CRS version 4.1.0 released'
```
Then googling for that title, and see if it fails in the CRS site. If it fails, just copying the `slug` part (the last part of the URL), and creating a new `slug: <>` field in the front matter.
