### PR TITLE
feat: update website to point to latest release

### DIFF
--- a/config/_default/params.yaml
+++ b/config/_default/params.yaml
@@ -13,7 +13,7 @@ images: ["/img/social-share.png"]
 
 crs:
   release_url_prefix: "https://github.com/coreruleset/coreruleset/releases/tag"
-  latest_major_version: "4.1.0"
+  latest_major_version: "4.2.0"
   prev_major_version: "3.3.5"
 
 github:


### PR DESCRIPTION
This PR updates the `latest_major_version` to the latest release 4.2.0.