### PR TITLE
fix: update git submodules using renovatebot

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,6 +8,7 @@ on:
 # Sets permissions of the GITHUB_TOKEN
 permissions:
   contents: read
+  issues: write
 
 # Default to bash
 defaults:
@@ -52,7 +53,8 @@ jobs:
           npx -y pagefind --site public
 
       - name: Restore lychee cache
-        uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # v4
+        id: restore-cache
+        uses: actions/cache/restore@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # v4
         with:
             path: .lycheecache
             key: cache-lychee-${{ github.sha }}
@@ -66,13 +68,18 @@ jobs:
             args: "-c lychee.toml --cache --max-cache-age 1d -E './content/**/*.md'"
             jobSummary: true
 
-              #      - name: Create Issue From File
-              #if: env.lychee_exit_code != 0
-              #uses: peter-evans/create-issue-from-file@v5
-              #permissions:
-              #issues: write
-              #with:
-              #title: Link Checker Report
-              #content-filepath: ./lychee/out.md
-              #labels: report, automated issue
+      - name: Create Issue From File
+        if: env.lychee_exit_code != 0
+        uses: peter-evans/create-issue-from-file@v5
+        with:
+          title: Link Checker Report
+          content-filepath: ./lychee/out.md
+          labels: report, automated issue
+
+      - name: Save lychee cache
+        uses: actions/cache/save@v4
+        if: always()
+        with:
+          path: .lycheecache
+          key: ${{ steps.restore-cache.outputs.cache-primary-key }}
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # CRS Project Website Repository
+[![Check Links](https://github.com/coreruleset/website/actions/workflows/test.yml/badge.svg)](https://github.com/coreruleset/website/actions/workflows/test.yml)
 
 This repository contains the website for the OWASP CRS Project.
 

--- a/lychee.toml
+++ b/lychee.toml
@@ -1,3 +1,3 @@
-exclude = ["piwik.netnea.com", "github.com/*", "trustwave.com", "www.redbubble.com", "stackoverflow.com", "gartner.com", "asciinema.org", "secjuice.com"]
+exclude = ["piwik.netnea.com", "github.com/*", "trustwave.com", "www.redbubble.com", "stackoverflow.com", "gartner.com", "asciinema.org", "secjuice.com", "vimeo.com"]
 user-agent = "Mozilla/5.0 (X11; Linux x86_64; rv:60.0) Gecko/20100101 Firefox/81.0"
 no-progress = true

--- a/renovate.json
+++ b/renovate.json
@@ -3,5 +3,8 @@
   "extends": [
     "local>coreruleset/renovate-config",
     "schedule:weekly"
-  ]
+  ],
+  "git-submodules": {
+    "enabled": true
+  }
 }


### PR DESCRIPTION
## what

- use renovatebot to update git submodules (docs)

## why

- git submodules where not being updates, hence docs were generating old versions

Fixes #115.

