### PR TITLE
fix: downgrade Hugo to 0.145.0

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -37,7 +37,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       # renovate: datasource=github-releases depName=gohugoio/hugo
-      HUGO_VERSION: 0.146.3
+      HUGO_VERSION: 0.145.0
     steps:
       - name: Install Hugo CLI
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       # renovate: datasource=github-releases depName=gohugoio/hugo
-      HUGO_VERSION: 0.146.3
+      HUGO_VERSION: 0.145.0
     steps:
       - name: Install Hugo CLI
         run: |

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "ISC",
       "dependencies": {
         "autoprefixer": "^10.4.19",
-        "hugo-extended": "^0.146.0",
+        "hugo-extended": "^0.145.0",
         "postcss": "^8.4.38",
         "postcss-cli": "^11.0.0"
       },
@@ -938,9 +938,9 @@
       }
     },
     "node_modules/hugo-extended": {
-      "version": "0.146.3",
-      "resolved": "https://registry.npmjs.org/hugo-extended/-/hugo-extended-0.146.3.tgz",
-      "integrity": "sha512-fL9lKaC1QNqnIR7WIrn/Ou+6ND0vU6BW0U25hMJipmS3gHaPc+LopuHdAhAR4to/HUWh9d1A95dqC1s2oD5wmg==",
+      "version": "0.145.0",
+      "resolved": "https://registry.npmjs.org/hugo-extended/-/hugo-extended-0.145.0.tgz",
+      "integrity": "sha512-ty+vVfBBxc6w9p4vKt1zbtIPLZi+N+3ibCfil18FtNpXuQhN3vwH/1KLNrj59tSZpMJjk12SosyeRHAefgIEXw==",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   "homepage": "https://github.com/coreruleset/website#readme",
   "dependencies": {
     "autoprefixer": "^10.4.19",
-    "hugo-extended": "^0.146.0",
+    "hugo-extended": "^0.145.0",
     "postcss": "^8.4.38",
     "postcss-cli": "^11.0.0"
   },

--- a/renovate.json
+++ b/renovate.json
@@ -20,5 +20,11 @@
       "depNameTemplate": "coreruleset/coreruleset",
       "datasourceTemplate": "github-releases"
     }
+  ],
+  "packageRules": [
+    {
+      "matchPackageNames": ["gohugoio/hugo"],
+      "allowedVersions": "<=0.145.0"
+    }
   ]
 }


### PR DESCRIPTION
Hugo 0.146.0 includes a new templating engine that isn't yet supported by the Relearn theme.