### PR TITLE
chore: add security headers

### DIFF
--- a/static/_headers
+++ b/static/_headers
@@ -2,7 +2,7 @@
   X-Frame-Options: DENY
   X-Content-Type-Options: nosniff
   Referrer-Policy: no-referrer
-  Permissions-Policy: microphone=(), geolocation=()
+  Permissions-Policy: microphone=(), geolocation=(), camera=()
 
   Content-Security-Policy: script-src 'self' https://coreruleset.org/; frame-ancestors 'none';
 


### PR DESCRIPTION
## what

- add security headers, even if our pages are static

## why

- why not?