### PR TITLE
fix: allow `unsafe-inline` scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,9 +7,9 @@
     "build": "hugo --theme=dot-org-hugo-theme --configDir=config --gc --minify --cleanDestinationDir",
     "start": "hugo serve --logLevel info --configDir=config --buildDrafts --buildFuture --ignoreCache --disableFastRender --gc  --printI18nWarnings --printMemoryUsage --printPathWarnings --printUnusedTemplates --templateMetrics --templateMetricsHints",
     "dev": "npm run dev:start",
-    "dev:start": "hugo serve --logLevel info --configDir=config --themesDir=../.. --buildDrafts --buildFuture --ignoreCache --disableFastRender --gc  --printI18nWarnings --printMemoryUsage --printPathWarnings --printUnusedTemplates --templateMetrics --templateMetricsHints",
-    "dev:start:with-pagefind": "hugo --baseURL=/ --themesDir=../.. --theme=dot-org-hugo-theme && npm_config_yes=true npx pagefind --site 'public' --output-subdir '../static/pagefind' && npm run dev:start",
-    "dev:build": "hugo --themesDir=../.. --theme=dot-org-hugo-theme"
+    "dev:start": "hugo serve --logLevel info --configDir=config --themesDir=themes --buildDrafts --buildFuture --ignoreCache --disableFastRender --gc  --printI18nWarnings --printMemoryUsage --printPathWarnings --printUnusedTemplates --templateMetrics --templateMetricsHints",
+    "dev:start:with-pagefind": "hugo --baseURL=/ --themesDir=themes --theme=dot-org-hugo-theme && npm_config_yes=true npx pagefind --site 'public' --output-subdir '../static/pagefind' && npm run dev:start",
+    "dev:build": "hugo --themesDir=themes --theme=dot-org-hugo-theme"
   },
   "repository": {
     "type": "git",

--- a/static/_headers
+++ b/static/_headers
@@ -4,7 +4,7 @@
   Referrer-Policy: no-referrer
   Permissions-Policy: microphone=(), geolocation=(), camera=()
 
-  Content-Security-Policy: script-src 'self' 'unsafe-inline' https://coreruleset.org/ https://*.pages.dev/; frame-ancestors 'none';
+  Content-Security-Policy: script-src 'self' 'unsafe-inline' https://coreruleset.org/ https://*.website-1u6.pages.dev/; frame-ancestors 'none';
 
 https://:project.pages.dev/*
   X-Robots-Tag: noindex

--- a/static/_headers
+++ b/static/_headers
@@ -4,7 +4,7 @@
   Referrer-Policy: no-referrer
   Permissions-Policy: microphone=(), geolocation=(), camera=()
 
-  Content-Security-Policy: script-src 'self' https://coreruleset.org/; frame-ancestors 'none';
+  Content-Security-Policy: script-src 'self' 'unsafe-inline' https://coreruleset.org/ https://*.pages.dev/; frame-ancestors 'none';
 
 https://:project.pages.dev/*
   X-Robots-Tag: noindex


### PR DESCRIPTION
The new Content Security Policy header breaks some functionality. Enable `unsafe-inline` for now.