### PR TITLE
chore: add redirect open waf day

### DIFF
--- a/content/blog/open-waf-day-2026-vienna/index.md
+++ b/content/blog/open-waf-day-2026-vienna/index.md
@@ -24,7 +24,7 @@ Following the success of our Barcelona 2025 event, we're bringing the community 
 
 Registration is now open! Please register using the form below to secure your spot:
 
-{{< button link="/register/open-waf-day-2026-viena" text="Register now!" >}}
+{{< button link="/register/open-waf-day-2026-vienna" text="Register now!" >}}
 
 ## Call for Presentations
 

--- a/content/blog/open-waf-day-2026-vienna/index.md
+++ b/content/blog/open-waf-day-2026-vienna/index.md
@@ -24,21 +24,11 @@ Following the success of our Barcelona 2025 event, we're bringing the community 
 
 Registration is now open! Please register using the form below to secure your spot:
 
-{{< button link="https://forms.gle/UckehAUPdR8xZVkd8" text="Register now!" >}}
+{{< button link="/register/open-waf-day-2026-viena" text="Register now!" >}}
 
 ## Call for Presentations
 
-We're looking for speakers to share their experiences, research, and insights on topics including:
-
-- Web Application Firewalls (ModSecurity, Coraza, and others)
-- OWASP CRS
-- WAF deployment strategies and best practices
-- Security automation and testing
-- Real-world WAF use cases and lessons learned
-- WAF performance and optimization
-- Integration with observability and monitoring tools
-
-{{< button link="https://forms.gle/PoBKhza7YcRLFdFU6" text="Send your presentation here" >}}
+**The Call for Presentations is now closed.** Thank you to everyone who submitted a proposal! We'll be in touch with speakers soon.
 
 ## What to Expect
 

--- a/static/_redirects
+++ b/static/_redirects
@@ -1,3 +1,3 @@
 /register/community-call https://luma.com/8yc1p543
 /redirect/community-call https://meet.google.com/hno-faiv-qmi
-
+/register/open-waf-day-2026-viena https://docs.google.com/forms/d/e/1FAIpQLSeq0sAN-yV9Yv0Voxr0rvaFkp9HcHr5UkyQ_5Qavq6s0HAy7w/viewform

--- a/static/_redirects
+++ b/static/_redirects
@@ -1,3 +1,3 @@
 /register/community-call https://luma.com/8yc1p543
 /redirect/community-call https://meet.google.com/hno-faiv-qmi
-/register/open-waf-day-2026-viena https://docs.google.com/forms/d/e/1FAIpQLSeq0sAN-yV9Yv0Voxr0rvaFkp9HcHr5UkyQ_5Qavq6s0HAy7w/viewform
+/register/open-waf-day-2026-vienna https://docs.google.com/forms/d/e/1FAIpQLSeq0sAN-yV9Yv0Voxr0rvaFkp9HcHr5UkyQ_5Qavq6s0HAy7w/viewform


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated Open WAF Day 2026 Vienna registration to use the site’s internal registration page instead of an external form.
  * Closed Call for Presentations; proposals are no longer being accepted.
  * Added a redirect for a legacy/misspelled registration link to ensure users reach the correct registration flow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->