### PR TITLE
fix: use matchDepNames in Renovate package rules to pin prev_major_version to v3

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -8,13 +8,12 @@
   },
   "packageRules": [
     {
-      "matchPackageNames": ["coreruleset-v3"],
-      "rangeStrategy": "bump-minor",
+      "matchDepNames": ["coreruleset-v3"],
       "allowedVersions": "<4.0.0",
       "groupName": "CRS v3 updates"
     },
     {
-      "matchPackageNames": ["coreruleset-v4"],
+      "matchDepNames": ["coreruleset-v4"],
       "allowedVersions": ">=4.0.0",
       "groupName": "CRS v4 updates"
     }


### PR DESCRIPTION
## Summary

- Replaces `matchPackageNames` with `matchDepNames` in both Renovate package rules
- Removes `rangeStrategy: bump-minor` from the v3 rule (no effect on pinned versions)

## Problem

`matchPackageNames` matches the registry `packageName`, which is `"coreruleset/coreruleset"` for both custom managers. It never matched `"coreruleset-v3"` or `"coreruleset-v4"` (those are `depName` values set by `depNameTemplate`). As a result, the `allowedVersions: "<4.0.0"` constraint was silently ignored, and Renovate would propose v4 updates for `prev_major_version`.

`matchDepNames` matches `depName`, which is what the custom managers actually set — fixing the constraint.

## Test plan

- [ ] Verify Renovate dry-run no longer proposes a v4 update for `prev_major_version`
- [ ] Verify Renovate still proposes v3 patch/minor updates for `prev_major_version`
- [ ] Verify Renovate still proposes v4 updates for `latest_major_version`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automated dependency update settings for Core Rule Set packages.
  * Adjusted how one update rule matches packages and removed a minor version bump preference from that rule.
  * Kept the v4 update group unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->