### PR TITLE
chore(renovate): exempt CRS releases from cooldown; rename version keys

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -10,12 +10,14 @@
     {
       "matchDepNames": ["coreruleset-v3"],
       "allowedVersions": "<4.0.0",
-      "groupName": "CRS v3 updates"
+      "groupName": "CRS v3 updates",
+      "minimumReleaseAge": "0 days"
     },
     {
       "matchDepNames": ["coreruleset-v4"],
       "allowedVersions": ">=4.0.0",
-      "groupName": "CRS v4 updates"
+      "groupName": "CRS v4 updates",
+      "minimumReleaseAge": "0 days"
     }
   ],
   "customManagers": [


### PR DESCRIPTION
Two related changes to the version-tracking setup:

**Renovate cooldown exemption**
The shared `coreruleset/renovate-config` sets a `minimumReleaseAge` of 7 days for all dependencies. CRS releases are first-party and the website should track them immediately. Adds `minimumReleaseAge: "0 days"` to the `coreruleset-v3` and `coreruleset-v4` package rules to override that default.

**Version key rename**
The `crs` block in `params.yaml` used generic names that didn't convey what the versions actually represent:
- `latest_major_version` → `latest_v4`
- `prev_major_version` → `lts_v3_version`

Updated all usages in `renovate.json`, `layouts/home.html`, `layouts/_partials/home/hero.html`, and `layouts/_partials/home/cards.html`.