### PR TITLE
Add connect-src for cloudflareinsights.com to CSP

### DIFF
--- a/static/_headers
+++ b/static/_headers
@@ -4,7 +4,7 @@
   Referrer-Policy: no-referrer
   Permissions-Policy: microphone=(), geolocation=(), camera=()
 
-  Content-Security-Policy: script-src 'self' 'unsafe-inline'  https://static.cloudflareinsights.com/beacon.min.js https://coreruleset.org/ https://*.website-1u6.pages.dev/; frame-ancestors 'none';
+  Content-Security-Policy: script-src 'self' 'unsafe-inline'  https://static.cloudflareinsights.com/beacon.min.js https://coreruleset.org/ https://*.website-1u6.pages.dev/; connect-src 'self' https://cloudflareinsights.com; frame-ancestors 'none';
 
 https://:project.pages.dev/*
   X-Robots-Tag: noindex


### PR DESCRIPTION
## Summary
- Add `connect-src 'self' https://cloudflareinsights.com` to the Content-Security-Policy in `static/_headers`
- The Cloudflare beacon script (already allowed under `script-src`) reports analytics via a fetch call to cloudflareinsights.com, which the CSP's `connect-src` did not previously allow

## Test plan
- [ ] Deploy preview and confirm no CSP `connect-src` violations are reported in the browser console for the Cloudflare beacon

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Updated content security settings to allow trusted connection telemetry while preserving existing script and framing protections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->